### PR TITLE
회원가입 및 로그인 &  OAuth2 로그인 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,17 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	//MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/thonlivethondie/artcorner/api/auth/AuthController.java
+++ b/src/main/java/thonlivethondie/artcorner/api/auth/AuthController.java
@@ -1,0 +1,100 @@
+package thonlivethondie.artcorner.api.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+import thonlivethondie.artcorner.api.auth.dto.TokenRefreshRequest;
+import thonlivethondie.artcorner.api.auth.dto.TokenRefreshResponse;
+import thonlivethondie.artcorner.api.auth.dto.LoginRequest;
+import thonlivethondie.artcorner.api.auth.dto.LoginResponse;
+import thonlivethondie.artcorner.entity.RefreshToken;
+import thonlivethondie.artcorner.entity.User;
+import thonlivethondie.artcorner.jwt.JwtHandler;
+import thonlivethondie.artcorner.jwt.JwtUserClaim;
+import thonlivethondie.artcorner.repository.RefreshTokenRepository;
+import thonlivethondie.artcorner.repository.UserRepository;
+import thonlivethondie.artcorner.entity.UserRole;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtHandler jwtHandler;
+
+    // 일반 로그인 API
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        // 1. 이메일 + 비밀번호로 인증 시도
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+        );
+
+        // 2. DB에서 사용자 조회
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 이메일입니다."));
+
+        // 3. 비밀번호 매칭 확인
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 4. JWT 발급
+        JwtUserClaim claim = new JwtUserClaim(user.getId(), user.getRole());
+        var tokens = jwtHandler.createTokens(claim);
+
+        // 5. RefreshToken DB에 저장 (기존 거 덮어씀)
+        refreshTokenRepository.save(
+                new RefreshToken(user.getId(), tokens.getRefreshToken())
+        );
+
+        // 6. 응답 반환
+        return ResponseEntity.ok(new LoginResponse(tokens.getAccessToken(), tokens.getRefreshToken()));
+    }
+
+    // RefreshToken 으로 AccessToken 재발급 API
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenRefreshResponse> refreshToken(@RequestBody TokenRefreshRequest request) {
+        String refreshToken = request.getRefreshToken();
+
+        // 1. refreshToken 파싱 (서명 확인 + 만료 여부)
+        var claimsOpt = jwtHandler.getClaims(refreshToken);
+        if (claimsOpt.isEmpty()) {
+            return ResponseEntity.status(401).build();
+        }
+
+        JwtUserClaim claims = claimsOpt.get();
+
+        // 2. DB에서 해당 userId의 refreshToken 조회
+        RefreshToken savedToken = refreshTokenRepository.findById(claims.userId())
+                .orElseThrow(() -> new RuntimeException("저장된 리프레시 토큰이 없습니다."));
+
+        // 3. 클라이언트가 보낸 refreshToken이 저장된 것과 일치하는지 확인
+        if (!savedToken.getToken().equals(refreshToken)) {
+            return ResponseEntity.status(401).build();
+        }
+
+        // 4. accessToken 재발급
+        String newAccessToken = jwtHandler.createAccessToken(claims);
+
+        return ResponseEntity.ok(new TokenRefreshResponse(newAccessToken));
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(@AssignUserId Long userId) {
+        refreshTokenRepository.findById(userId)
+                .ifPresent(refreshTokenRepository::delete);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/api/auth/LogoutController.java
+++ b/src/main/java/thonlivethondie/artcorner/api/auth/LogoutController.java
@@ -1,0 +1,27 @@
+package thonlivethondie.artcorner.api.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import thonlivethondie.artcorner.jwt.JwtHandler;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class LogoutController {
+
+    private final JwtHandler jwtHandler;
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal Long userId, HttpServletRequest request, HttpServletResponse response) {
+        // TODO: RefreshToken DB 또는 Redis에서 삭제 로직 구현 필요 (여기서는 단순 응답 처리)
+        // 프론트가 AccessToken, RefreshToken 클라이언트에서 삭제해야 함
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/api/auth/dto/LoginRequest.java
+++ b/src/main/java/thonlivethondie/artcorner/api/auth/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package thonlivethondie.artcorner.api.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/thonlivethondie/artcorner/api/auth/dto/LoginResponse.java
+++ b/src/main/java/thonlivethondie/artcorner/api/auth/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package thonlivethondie.artcorner.api.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/thonlivethondie/artcorner/api/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/thonlivethondie/artcorner/api/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,8 @@
+package thonlivethondie.artcorner.api.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRefreshRequest {
+    private String refreshToken;
+}

--- a/src/main/java/thonlivethondie/artcorner/api/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/thonlivethondie/artcorner/api/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,10 @@
+package thonlivethondie.artcorner.api.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenRefreshResponse {
+    private String accessToken;
+}

--- a/src/main/java/thonlivethondie/artcorner/api/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/thonlivethondie/artcorner/api/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package thonlivethondie.artcorner.api.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import thonlivethondie.artcorner.entity.User;
+import thonlivethondie.artcorner.repository.UserRepository;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 이메일입니다."));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())
+                .password(user.getPassword())
+                .roles(user.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/api/dummy.java
+++ b/src/main/java/thonlivethondie/artcorner/api/dummy.java
@@ -1,0 +1,4 @@
+package thonlivethondie.artcorner.api;
+
+public class dummy {
+}

--- a/src/main/java/thonlivethondie/artcorner/config/SchedulerConfig.java
+++ b/src/main/java/thonlivethondie/artcorner/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package thonlivethondie.artcorner.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+    // 스케줄링 기능 활성화용 설정 클래스 (내용 없음)
+}

--- a/src/main/java/thonlivethondie/artcorner/config/SecurityConfig.java
+++ b/src/main/java/thonlivethondie/artcorner/config/SecurityConfig.java
@@ -1,0 +1,83 @@
+package thonlivethondie.artcorner.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import thonlivethondie.artcorner.api.auth.service.CustomUserDetailsService;
+import thonlivethondie.artcorner.jwt.JwtAuthenticationFilter;
+import thonlivethondie.artcorner.jwt.TokenProvider;
+import thonlivethondie.artcorner.oauth.handler.OAuth2AuthenticationFailureHandler;
+import thonlivethondie.artcorner.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import thonlivethondie.artcorner.oauth.service.CustomOAuth2UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .formLogin().disable()
+                .httpBasic().disable()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .failureHandler(oAuth2AuthenticationFailureHandler)
+                )
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(authenticationManager());
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Bean
+    public DaoAuthenticationProvider daoAuthenticationProvider(PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(customUserDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        return provider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(List.of(daoAuthenticationProvider(passwordEncoder()), tokenProvider));
+    }
+
+}
+
+

--- a/src/main/java/thonlivethondie/artcorner/entity/RefreshToken.java
+++ b/src/main/java/thonlivethondie/artcorner/entity/RefreshToken.java
@@ -1,0 +1,34 @@
+package thonlivethondie.artcorner.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    private Long userId; // user_id가 PK (1:1 관계)
+
+    @Column(nullable = false, length = 500)
+    private String token;
+
+    public void updateToken(String newToken) {
+        this.token = newToken;
+    }
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    @Builder
+    public RefreshToken(Long userId, String token) {
+        this.userId = userId;
+        this.token = token;
+        this.expiryDate = LocalDateTime.now().plusWeeks(2); // 2주 유효
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/entity/User.java
+++ b/src/main/java/thonlivethondie/artcorner/entity/User.java
@@ -1,11 +1,15 @@
 package thonlivethondie.artcorner.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+import thonlivethondie.artcorner.oauth.user.OAuth2Provider;
 
 /**
  * 테스트 삼아 올려본 엔티티
  * Docker를 통해 MySQL을 띄운 후, JPA를 통해 제대로 동작하는 것을 확인함
  */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class User {
     @Id
@@ -16,7 +20,6 @@ public class User {
     @Column(name = "email", nullable = false)
     private String email;
 
-    // OAuth 사용자는 null 가능
     @Column(name = "password")
     private String password;
 
@@ -24,4 +27,25 @@ public class User {
     private String nickname;
 
     private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    private OAuth2Provider provider;
+
+    @Column(name = "provider_id")
+    private String providerId;
+
+    @Builder
+    public User(String email, String password, String nickname,
+                String socialId, UserRole role, OAuth2Provider provider, String providerId) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.socialId = socialId;
+        this.role = role;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
 }

--- a/src/main/java/thonlivethondie/artcorner/entity/UserRole.java
+++ b/src/main/java/thonlivethondie/artcorner/entity/UserRole.java
@@ -1,0 +1,6 @@
+package thonlivethondie.artcorner.entity;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/JwtAuthentication.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/JwtAuthentication.java
@@ -1,0 +1,53 @@
+package thonlivethondie.artcorner.jwt;
+
+import thonlivethondie.artcorner.entity.UserRole;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+
+public record JwtAuthentication(
+        Long userId,
+        UserRole role
+) implements Authentication {
+
+    public JwtAuthentication(JwtUserClaim claims) {
+        this(claims.userId(), claims.role());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(this.role().name()));
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {}
+
+    @Override
+    public String getName() {
+        return String.valueOf(userId);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package thonlivethondie.artcorner.jwt;
+
+import thonlivethondie.artcorner.jwt.exception.JwtAuthenticationException;
+import thonlivethondie.artcorner.jwt.exception.JwtNotExistException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        Optional<String> tokenOptional = resolveToken(request);
+
+        if (tokenOptional.isEmpty()) {
+            filterChain.doFilter(request, response); // 토큰 없으면 다음 필터로 넘김
+            return;
+        }
+
+        try {
+            String tokenValue = tokenOptional.get();
+            JwtAuthenticationToken token = new JwtAuthenticationToken(tokenValue);
+            Authentication authentication = this.authenticationManager.authenticate(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (JwtAuthenticationException e) {
+            handleJwtException(response, e);
+        }
+    }
+
+    private Optional<String> resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+            return Optional.of(bearerToken.substring(BEARER_PREFIX.length()));
+        }
+        return Optional.empty();
+    }
+
+    private void handleJwtException(HttpServletResponse response, JwtAuthenticationException e) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String errorResponse = objectMapper.writeValueAsString(
+                new ErrorResponse("UNAUTHORIZED", e.getMessage())
+        );
+        response.getWriter().write(errorResponse);
+        response.flushBuffer();
+    }
+
+    // 간단한 에러 응답 객체
+    private record ErrorResponse(String error, String message) {}
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,45 @@
+package thonlivethondie.artcorner.jwt;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public record JwtAuthenticationToken(
+        String token
+) implements Authentication {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return token;
+    }
+
+    @Override
+    public Object getDetails() {
+        return token;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {}
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/JwtHandler.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/JwtHandler.java
@@ -1,0 +1,86 @@
+package thonlivethondie.artcorner.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import thonlivethondie.artcorner.entity.UserRole;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+public class JwtHandler {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpireIn;
+    private final long refreshTokenExpireIn;
+
+    public static final String USER_ID = "USER_ID";
+    public static final String USER_ROLE = "USER_ROLE";
+
+    public JwtHandler(String secret, long accessTokenExpireIn, long refreshTokenExpireIn) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpireIn = accessTokenExpireIn;
+        this.refreshTokenExpireIn = refreshTokenExpireIn;
+    }
+
+    public String createAccessToken(JwtUserClaim claim) {
+        return Jwts.builder()
+                .subject("AccessToken")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpireIn))
+                .claims(Map.of(
+                        USER_ID, claim.userId(),
+                        USER_ROLE, claim.role().name()
+                ))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken() {
+        return Jwts.builder()
+                .subject("RefreshToken")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpireIn))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public JwtUserClaim parseToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return convert(claims);
+    }
+
+    public Optional<JwtUserClaim> getClaims(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return Optional.of(convert(claims));
+        } catch (ExpiredJwtException e) {
+            return Optional.of(convert(e.getClaims()));
+        } catch (JwtException | IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    private JwtUserClaim convert(Claims claims) {
+        Long userId = claims.get(USER_ID, Number.class).longValue();
+        UserRole role = UserRole.valueOf(claims.get(USER_ROLE, String.class));
+        return new JwtUserClaim(userId, role);
+    }
+
+    public JwtTokenPair createTokens(JwtUserClaim claim) {
+        String accessToken = createAccessToken(claim);
+        String refreshToken = createRefreshToken();
+        return new JwtTokenPair(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/JwtProperties.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package thonlivethondie.artcorner.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+
+public class JwtProperties {
+    private String secretKey;
+    private int accessTokenExpireIn;
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/JwtTokenPair.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/JwtTokenPair.java
@@ -1,0 +1,11 @@
+package thonlivethondie.artcorner.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtTokenPair {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/JwtUserClaim.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/JwtUserClaim.java
@@ -1,0 +1,15 @@
+package thonlivethondie.artcorner.jwt;
+
+
+import thonlivethondie.artcorner.entity.User;
+import thonlivethondie.artcorner.entity.UserRole;
+
+
+public record JwtUserClaim(
+        Long userId,
+        UserRole role
+) {
+    public static JwtUserClaim create(Long userId, UserRole role) {
+        return new JwtUserClaim(userId, role);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/TokenProvider.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/TokenProvider.java
@@ -1,0 +1,37 @@
+package thonlivethondie.artcorner.jwt;
+
+import thonlivethondie.artcorner.jwt.exception.JwtTokenExpiredException;
+import thonlivethondie.artcorner.jwt.exception.JwtTokenInvalidException;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class TokenProvider implements AuthenticationProvider {
+
+    private final JwtHandler jwtHandler;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+        String tokenValue = jwtAuthenticationToken.token();
+
+        try {
+            JwtUserClaim claims = jwtHandler.parseToken(tokenValue);
+            return new JwtAuthentication(claims);
+        } catch (ExpiredJwtException e) {
+            throw new JwtTokenExpiredException(e);
+        } catch (Exception e) {
+            throw new JwtTokenInvalidException(e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtAuthenticationException.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtAuthenticationException.java
@@ -1,0 +1,13 @@
+package thonlivethondie.artcorner.jwt.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(String message) {
+        super(message);
+    }
+
+    public JwtAuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtNotExistException.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtNotExistException.java
@@ -1,0 +1,7 @@
+package thonlivethondie.artcorner.jwt.exception;
+
+public class JwtNotExistException extends JwtAuthenticationException {
+    public JwtNotExistException() {
+        super("JWT 토큰이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtTokenExpiredException.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtTokenExpiredException.java
@@ -1,0 +1,7 @@
+package thonlivethondie.artcorner.jwt.exception;
+
+public class JwtTokenExpiredException extends JwtAuthenticationException {
+    public JwtTokenExpiredException(Throwable cause) {
+        super("JWT 토큰이 만료.", cause);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtTokenInvalidException.java
+++ b/src/main/java/thonlivethondie/artcorner/jwt/exception/JwtTokenInvalidException.java
@@ -1,0 +1,7 @@
+package thonlivethondie.artcorner.jwt.exception;
+
+public class JwtTokenInvalidException extends JwtAuthenticationException {
+    public JwtTokenInvalidException(Throwable cause) {
+        super("JWT 토큰이 유효하지 않dkdy.", cause);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/thonlivethondie/artcorner/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,21 @@
+package thonlivethondie.artcorner.oauth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        exception.printStackTrace();
+        response.sendRedirect("/login?error");
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/thonlivethondie/artcorner/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,49 @@
+package thonlivethondie.artcorner.oauth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import thonlivethondie.artcorner.jwt.JwtHandler;
+import thonlivethondie.artcorner.jwt.JwtUserClaim;
+import thonlivethondie.artcorner.entity.UserRole;
+import thonlivethondie.artcorner.oauth.service.OAuth2UserPrincipal;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtHandler jwtHandler;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        OAuth2UserPrincipal principal = (OAuth2UserPrincipal) authentication.getPrincipal();
+
+        Long userId = principal.getUser().getId();
+        UserRole role = principal.getUser().getRole();
+
+        JwtUserClaim claim = new JwtUserClaim(userId, role);
+        String accessToken = jwtHandler.createAccessToken(claim);
+        String refreshToken = jwtHandler.createRefreshToken();
+
+        String targetUrl = "http://localhost:5173/auth/success";
+
+        String redirectUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        log.info("OAuth2 로그인 성공, 리다이렉트 URL: {}", redirectUrl);
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/thonlivethondie/artcorner/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,57 @@
+package thonlivethondie.artcorner.oauth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import thonlivethondie.artcorner.entity.User;
+import thonlivethondie.artcorner.entity.UserRole;
+import thonlivethondie.artcorner.jwt.JwtTokenPair;
+import thonlivethondie.artcorner.jwt.JwtUserClaim;
+import thonlivethondie.artcorner.oauth.user.OAuth2Provider;
+import thonlivethondie.artcorner.oauth.user.OAuth2UserInfo;
+import thonlivethondie.artcorner.repository.UserRepository;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest request) {
+        Map<String, Object> attributes = super.loadUser(request).getAttributes();
+        String registrationId = request.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = request.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+        String providerId = attributes.get(userNameAttributeName).toString();
+
+        OAuth2UserInfo userInfo = OAuth2UserInfo.of(registrationId, attributes);
+        User user = getOrSave(userInfo, registrationId, providerId);
+
+        return new OAuth2UserPrincipal(user, attributes, userNameAttributeName);
+    }
+
+    private User getOrSave(OAuth2UserInfo userInfo, String registrationId, String providerId) {
+        OAuth2Provider provider = OAuth2Provider.from(registrationId);
+
+        return userRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .email(userInfo.email())
+                                .nickname(userInfo.name()) // ✅ 수정됨
+                                .role(UserRole.USER)
+                                .provider(provider)
+                                .providerId(providerId)
+                                .build()
+                ));
+
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/oauth/service/OAuth2UserPrincipal.java
+++ b/src/main/java/thonlivethondie/artcorner/oauth/service/OAuth2UserPrincipal.java
@@ -1,0 +1,38 @@
+package thonlivethondie.artcorner.oauth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import thonlivethondie.artcorner.entity.User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class OAuth2UserPrincipal implements OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+    private final String attributeKey;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(attributeKey).toString();
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/oauth/user/KakaoProperties.java
+++ b/src/main/java/thonlivethondie/artcorner/oauth/user/KakaoProperties.java
@@ -1,0 +1,16 @@
+package thonlivethondie.artcorner.oauth.user;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.security.oauth2.client.registration.kakao")
+public class KakaoProperties {
+    private String clientId;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/oauth/user/OAuth2Provider.java
+++ b/src/main/java/thonlivethondie/artcorner/oauth/user/OAuth2Provider.java
@@ -1,0 +1,21 @@
+package thonlivethondie.artcorner.oauth.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuth2Provider {
+    GOOGLE("google"),
+    KAKAO("kakao");
+
+    private final String registrationId;
+
+    public static OAuth2Provider from(String id) {
+        return switch (id) {
+            case "google" -> GOOGLE;
+            case "kakao" -> KAKAO;
+            default -> throw new IllegalArgumentException("Unknown provider: " + id);
+        };
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/oauth/user/OAuth2UserInfo.java
+++ b/src/main/java/thonlivethondie/artcorner/oauth/user/OAuth2UserInfo.java
@@ -1,0 +1,41 @@
+package thonlivethondie.artcorner.oauth.user;
+
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@Slf4j
+@Builder
+public record OAuth2UserInfo(
+        String name,
+        String email,
+        String profile
+) {
+    public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId) {
+            case "google" -> ofGoogle(attributes);
+            case "kakao" -> ofKakao(attributes);
+            default -> throw new IllegalArgumentException("Unsupported registrationId: " + registrationId);
+        };
+    }
+
+    private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
+        return OAuth2UserInfo.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .profile((String) attributes.get("picture"))
+                .build();
+    }
+
+    private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        return OAuth2UserInfo.builder()
+                .name((String) profile.get("nickname"))
+                .email((String) account.get("email"))
+                .profile((String) profile.get("profile_image_url"))
+                .build();
+    }
+}

--- a/src/main/java/thonlivethondie/artcorner/repository/RefreshTokenRepository.java
+++ b/src/main/java/thonlivethondie/artcorner/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package thonlivethondie.artcorner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import thonlivethondie.artcorner.entity.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/thonlivethondie/artcorner/repository/UserRepository.java
+++ b/src/main/java/thonlivethondie/artcorner/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package thonlivethondie.artcorner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import thonlivethondie.artcorner.entity.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/thonlivethondie/artcorner/scheduler/RefreshTokenScheduler.java
+++ b/src/main/java/thonlivethondie/artcorner/scheduler/RefreshTokenScheduler.java
@@ -1,0 +1,35 @@
+package thonlivethondie.artcorner.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import thonlivethondie.artcorner.jwt.JwtHandler;
+import thonlivethondie.artcorner.repository.RefreshTokenRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtHandler jwtHandler;
+
+    /**
+     * 매일 새벽 3시에 만료된 리프레시 토큰 삭제
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    public void removeExpiredRefreshTokens() {
+        log.info("만료된 리프레시 토큰 삭제 작업 시작");
+
+        refreshTokenRepository.findAll().forEach(token -> {
+            var claimsOpt = jwtHandler.getClaims(token.getToken());
+            if (claimsOpt.isEmpty()) {
+                log.info("만료된 토큰 삭제: userId={}", token.getUserId());
+                refreshTokenRepository.delete(token);
+            }
+        });
+
+        log.info("리프레시 토큰 삭제 완료");
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/artcorner
+    username: root
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+server:
+  port: 443
+  ssl:
+    enabled: true
+    key-store: file:/home/ubuntu/keystore.p12
+    key-store-password: ${SSL_SECRET}
+    key-store-type: PKCS12
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3307/artcorner
+    username: prod_user
+    password: prod_password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,60 @@
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access-token-expire-in: 3600
+  refresh-token-expire-in: 1209600
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: 176525994307-3a193lc7db9ip07hs1296sn35b8u8hps.apps.googleusercontent.com
+            client-secret: ${GOOGLE_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            scope:
+              - profile
+              - email
+
+          kakao:
+            client-id: 3d455d387676771824fbfed1c681a87e
+            client-secret: ${KAKAO_SECRET}
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            scope:
+              - account_email
+              - profile_nickname
+              - profile_image
+
+          naver:
+            client-id: { 네이버-클라이언트-ID }
+            client-secret: { 네이버-시크릿 }
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+              - profile_image
+            client-name: Naver
+            client-authentication-method: client_secret_post
+
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,4 @@ spring:
       - security/application-db.yml
       - security/application-jwt.yml
       - security/application-oauth.yml
+


### PR DESCRIPTION
- Google과 Kakao OAuth2 로그인을 연결했습니다.
- 로그인 성공 시 JWT AccessToken과 RefreshToken을 만들어서 프론트에 보냅니다.
- OAuth2User 정보를 받아서 회원이 없으면 새로 저장하고, 있으면 불러옵니다.
- User 엔티티에 OAuth2 관련 정보도 추가했습니다.
- Security 설정에 OAuth2 로그인과 JWT 인증 필터를 넣었습니다.